### PR TITLE
Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent guidelines
+
+Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working in this repo.
+
+## Project overview
+
+<!-- TODO: one paragraph describing what this repo does -->
+
+## Local setup
+
+<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
+
+```bash
+# Example
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+```
+
+## Branch naming
+
+Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-in-pipeline`).
+
+## Coding standards
+
+- Match the style already in the file you are editing.
+- Prefer clear, minimal changes over large refactors unless explicitly asked.
+- Do not add comments that describe *what* the code does — only add comments when the *why* is non-obvious.
+- Do not introduce new dependencies without checking with the maintainer.
+
+## Running tests
+
+<!-- TODO: exact command to run tests -->
+
+```bash
+# Example
+make test
+```
+
+Always run tests before declaring a task complete.
+
+## How to submit changes
+
+1. Create a branch: `git checkout -b <type>/<description>`.
+2. Commit with a clear message focused on *why*, not *what*.
+3. Open a pull request against `main`.
+4. Do **not** push directly to `main`.
+
+## What to avoid
+
+- Do not reformat files unrelated to your change.
+- Do not remove error handling or tests.
+- Do not commit secrets, credentials, or large binary files.
+- Do not amend published commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,21 @@ Instructions for AI coding agents (Claude Code, Copilot, Cursor, etc.) working i
 
 ## Project overview
 
-<!-- TODO: one paragraph describing what this repo does -->
+`redis-zbench-go` is a Go benchmark tool for Redis **Sorted Sets**. It drives `ZADD` (load mode) and `ZRANGEBYLEX` / `ZRANGEBYSCORE` (query mode) workloads against a standalone or OSS-cluster Redis deployment, with configurable concurrency, pipelining, multi-exec transactions, keyspace size, element size, and RPS limits. The tool emits throughput and HDR-histogram latency summaries. It is published as a single self-contained binary for Linux and macOS (amd64 and arm64).
 
 ## Local setup
 
-<!-- TODO: mirror the setup steps from CONTRIBUTING.md -->
-
 ```bash
-# Example
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
+git clone git@github.com:redis-performance/redis-zbench-go.git
+cd redis-zbench-go
+# Download all Go module dependencies
+GO111MODULE=on go get -t -v ./...
+# Build the binary
+make build
+# The compiled binary lands in the current directory as ./redis-zbench-go
 ```
+
+Requires **Go 1.16 or later**. A running Redis instance is needed for integration tests (default: `127.0.0.1:6379`).
 
 ## Branch naming
 
@@ -29,11 +33,16 @@ Same as human contributors: `<type>/<short-description>` (e.g. `fix/off-by-one-i
 
 ## Running tests
 
-<!-- TODO: exact command to run tests -->
+```bash
+make test
+```
+
+This formats all Go source files with `gofmt`, then runs `go test -race -covermode=atomic ./...`. A Redis instance must be reachable on `127.0.0.1:6379`.
+
+To also generate a coverage report:
 
 ```bash
-# Example
-make test
+make coverage
 ```
 
 Always run tests before declaring a task complete.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+We treat this repo as "Open Source" within Redis: anyone who clears the bar below is welcome to contribute.
+
+## Local setup
+
+<!-- TODO: fill in repo-specific setup steps -->
+
+```bash
+# Example — replace with actual steps
+git clone git@github.com:redis-performance/<repo>.git
+cd <repo>
+# install dependencies, build, etc.
+```
+
+## Branch naming
+
+```
+<type>/<short-description>
+```
+
+Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+Example: `feat/add-pipeline-mode`
+
+## Coding standards
+
+- Keep changes focused; one logical change per PR.
+- Follow the conventions already present in the codebase (formatting, naming, error handling).
+- No dead code, no commented-out blocks.
+
+## Submitting changes
+
+1. Fork or create a branch from `main`.
+2. Make your changes with clear, atomic commits.
+3. Open a pull request against `main` with a descriptive title and summary.
+4. Address review comments promptly; force-push to the same branch to update.
+
+## Testing
+
+- All new behaviour must be covered by tests.
+- Existing tests must pass: run the test suite locally before opening a PR.
+- Coverage should not decrease.
+
+<!-- TODO: add the exact test command for this repo -->
+
+## Review process
+
+- At least one maintainer approval is required before merge.
+- CI must be green.
+- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,16 @@ We treat this repo as "Open Source" within Redis: anyone who clears the bar belo
 
 ## Local setup
 
-<!-- TODO: fill in repo-specific setup steps -->
-
 ```bash
-# Example — replace with actual steps
-git clone git@github.com:redis-performance/<repo>.git
-cd <repo>
-# install dependencies, build, etc.
+git clone git@github.com:redis-performance/redis-zbench-go.git
+cd redis-zbench-go
+# Download all Go module dependencies
+GO111MODULE=on go get -t -v ./...
+# Build the binary
+make build
 ```
+
+Requires **Go 1.16 or later**. No other system dependencies are needed beyond a running Redis instance for integration tests.
 
 ## Branch naming
 
@@ -42,10 +44,22 @@ Example: `feat/add-pipeline-mode`
 - Existing tests must pass: run the test suite locally before opening a PR.
 - Coverage should not decrease.
 
-<!-- TODO: add the exact test command for this repo -->
+Run the full test suite (requires a Redis instance on `127.0.0.1:6379`):
+
+```bash
+make test
+```
+
+This runs `gofmt` for formatting checks and `go test -race -covermode=atomic ./...` under the hood.
+
+To also produce a coverage report:
+
+```bash
+make coverage
+```
 
 ## Review process
 
 - At least one maintainer approval is required before merge.
 - CI must be green.
-- Maintainers may request changes or close PRs that don't meet the bar — this is normal and not personal.
+- Maintainers may request changes or close PRs that do not meet the bar — this is normal and not personal.


### PR DESCRIPTION
## Summary
- Adds baseline `CONTRIBUTING.md` (project setup, coding standards, PR workflow, testing, review process)
- Adds `AGENTS.md` with AI agent guidelines

Part of the Redis "Open Source within Redis" initiative — ensuring every repo in the org has clear contribution and agent guidelines to enable cross-team contributions.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)